### PR TITLE
head-undefined-not-never

### DIFF
--- a/lib/Tuple.ts
+++ b/lib/Tuple.ts
@@ -16,7 +16,7 @@ import { Decrement } from "./Count";
 export type Head<XS extends any[]> = XS extends [infer X, ...any[]]
   ? X
   : XS extends []
-  ? never
+  ? undefined
   : XS[number] | undefined;
 
 /**

--- a/lib/__tests__/Tuple.spec.ts
+++ b/lib/__tests__/Tuple.spec.ts
@@ -26,7 +26,8 @@ import {
 // Head
 //
 {
-  Assert<IsExactType<never, Head<[]>>>();
+  Assert<IsExactType<undefined, Head<[]>>>();
+  Assert<IsExactType<1 | undefined, Head<[] | [1]>>>();
   Assert<IsExactType<1, Head<[1]>>>();
   Assert<IsExactType<1, Head<[1, 2, 3]>>>();
   Assert<IsExactType<"Hello", Head<["Hello", "World"]>>>();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typebolt",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "TypeScript static helpers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
`Head<[]>` now will infer to `undefined` instead of `never`.

This allows `Head<[] | [1]>`  to infer to `1 | undefined` instead of `1`.